### PR TITLE
SSH Jumphost with github authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,16 @@
 
 ### Updating
 - Change `chart/requirements.yaml` ambassador version to an updated one.
+- Get the gitAuth parameters (organisation and API token) at hand.
 
 ```
 helm repo add datawire https://www.getambassador.io
 helm dep update
-helm upgrade --install --wait silta-cluster chart/ 
+helm upgrade --install --wait silta-cluster chart/  --set gitAuth.organisation='<ORG_NAME>' --set gitAuth.apiToken='<API_TOKEN>'
 ```
+
+#### SSH Jumphost
+
+SSH Jumphost authentication is based on [sshd-gitAuth](https://github.com/wunderio/sshd-gitauth) project that will authorize users based on their SSH private key. The key whitelist is built by listing all users that belong to a certain github organisation.
+
+You need to supply Github API Personal access token that will be used to get the list of organisation users. The access can be read only, following permissions are sufficient for the task: `public_repo, read:org, read:public_key, repo:status`.

--- a/chart/templates/sshd-jumpserver.yaml
+++ b/chart/templates/sshd-jumpserver.yaml
@@ -1,0 +1,36 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-jumpserver
+spec:
+  ports:
+    - name: ssh
+      port: 22
+  type: "LoadBalancer"
+  selector:
+    name: {{ .Release.Name }}-jumpserver
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}-jumpserver
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        name: {{ .Release.Name }}-jumpserver
+    spec:
+      containers:
+      - name: {{ .Release.Name }}-jumpserver
+        image: wunderio/sshd-gitauth:v0.1
+        ports:
+          - containerPort: 22
+        env:
+          - name: GITAUTH_API_TOKEN
+            value: "{{ .Values.gitAuth.apiToken }}"
+          - name: GITAUTH_HOST
+            value: "{{ .Values.gitAuth.host }}"
+          - name: GITAUTH_ORGANISATION
+            value: "{{ .Values.gitAuth.organisation }}"

--- a/chart/templates/sshd-jumpserver.yaml
+++ b/chart/templates/sshd-jumpserver.yaml
@@ -29,8 +29,8 @@ spec:
           - containerPort: 22
         env:
           - name: GITAUTH_API_TOKEN
-            value: "{{ .Values.gitAuth.apiToken }}"
+            value: {{ required "A valid .Values.gitAuth.apiToken entry required!" .Values.gitAuth.apiToken | quote }}
           - name: GITAUTH_HOST
-            value: "{{ .Values.gitAuth.host }}"
+            value: {{ required "A valid .Values.gitAuth.apiToken entry required!" .Values.gitAuth.host | quote }}
           - name: GITAUTH_ORGANISATION
-            value: "{{ .Values.gitAuth.organisation }}"
+            value: {{ required "A valid .Values.gitAuth.apiToken entry required!" .Values.gitAuth.organisation | quote }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -7,3 +7,9 @@ nfs-server-provisioner:
     size: 10Gi
   storageClass:
     defaultClass: false
+
+# SSH Jumphost settings
+gitAuth:
+  host: 'github.com'
+  organisation: 'you need to pass in a value for shell.gitAuth.organisation to your helm chart'
+  apiToken: 'you need to pass in a value for shell.gitAuth.apiToken to your helm chart'

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1,5 +1,3 @@
-
-
 nfs-server-provisioner:
   persistence:
     enabled: true
@@ -11,5 +9,5 @@ nfs-server-provisioner:
 # SSH Jumphost settings
 gitAuth:
   host: 'github.com'
-  organisation: 'you need to pass in a value for shell.gitAuth.organisation to your helm chart'
-  apiToken: 'you need to pass in a value for shell.gitAuth.apiToken to your helm chart'
+  organisation: ''
+  apiToken: ''


### PR DESCRIPTION
**Description:**

SSH Jumphost authentication is based on [sshd-gitauth](https://github.com/wunderio/sshd-gitauth) project that will authorize users based on their SSH private key. The key whitelist is built by listing all users that belong to a certain github organisation.

You need to supply Github API Personal access token that will be used to get the list of organisation users. The access can be read only, following permissions are sufficient for the task: `public_repo, read:org, read:public_key, repo:status`.

**Testing:**

It's deployed as a separate resource in the cluster currently, get the IP of resource with `kubectl describe svc silta-cluster-test-jumpserver` and try to connect either as root or www-admin.

