### PR TITLE
Deployment remover

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 chart/charts
 .idea
+local-values.yaml

--- a/README.md
+++ b/README.md
@@ -1,5 +1,15 @@
 # silta cluster
 
+### Installing
+
+1. Copy `chart/values.yaml` to `local-values.yaml` and fill out information.
+
+2. Deploy chart to cluster using local values. 
+```
+helm upgrade --install --wait silta-cluster chart/  --values local-values.yaml
+```
+
+
 ### Updating
 - Change `chart/requirements.yaml` ambassador version to an updated one.
 - Get the gitAuth parameters (organisation and API token) at hand.
@@ -7,7 +17,7 @@
 ```
 helm repo add datawire https://www.getambassador.io
 helm dep update
-helm upgrade --install --wait silta-cluster chart/  --set gitAuth.organisation='<ORG_NAME>' --set gitAuth.apiToken='<API_TOKEN>'
+helm upgrade --install --wait silta-cluster chart/  --values local-values.yaml
 ```
 
 #### SSH Jumphost
@@ -15,3 +25,7 @@ helm upgrade --install --wait silta-cluster chart/  --set gitAuth.organisation='
 SSH Jumphost authentication is based on [sshd-gitAuth](https://github.com/wunderio/sshd-gitauth) project that will authorize users based on their SSH private key. The key whitelist is built by listing all users that belong to a certain github organisation.
 
 You need to supply Github API Personal access token that will be used to get the list of organisation users. The access can be read only, following permissions are sufficient for the task: `public_repo, read:org, read:public_key, repo:status`.
+
+#### Deployment remover
+
+This is an exposed webhook that listens for branch delete events, logs in to cluster and removes named deployments using helm. Project code can be inspected at [silta-deployment-remover](https://github.com/wunderio/silta-deployment-remover).

--- a/chart/requirements.lock
+++ b/chart/requirements.lock
@@ -4,6 +4,9 @@ dependencies:
   version: 0.1.5
 - name: ambassador
   repository: https://www.getambassador.io
-  version: 0.40.1
-digest: sha256:1027db722fda0e91e7b7aa6444175ee4c84b171d66a5f99bc725af99a7f3548f
-generated: 2018-10-31T07:39:23.072016605Z
+  version: 0.40.2
+- name: redis
+  repository: https://kubernetes-charts.storage.googleapis.com/
+  version: 4.3.1
+digest: sha256:097442ea8ec417b1d1238d1297718ccad406d4b11dc0db29452d61c63f01a840
+generated: 2018-12-04T13:08:40.078099721Z

--- a/chart/requirements.yaml
+++ b/chart/requirements.yaml
@@ -5,3 +5,6 @@ dependencies:
 - name: ambassador
   version: 0.40.x
   repository: https://www.getambassador.io
+- name: redis
+  version: 4.3.x
+  repository: https://kubernetes-charts.storage.googleapis.com/

--- a/chart/templates/deployment-remover.yaml
+++ b/chart/templates/deployment-remover.yaml
@@ -25,14 +25,6 @@ apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: {{ .Release.Name }}-deployment-remover
-  annotations:
-    pod.beta.kubernetes.io/init-containers: '[
-      {
-        "name": "wait-redis",
-        "image": "busybox",
-        "command": ["sh", "-c", "until nslookup {{ .Release.Name }}-redis-master; do echo waiting for redis; sleep 2; done;"]
-      },
-    ]'
 spec:
   replicas: 1
   template:
@@ -40,6 +32,10 @@ spec:
       labels:
         name: {{ .Release.Name }}-deployment-remover
     spec:
+      initContainers:
+      - name: wait-redis
+        image: busybox
+        command: ["sh", "-c", "until nslookup {{ .Release.Name }}-redis-master; do echo waiting for redis; sleep 2; done;"]
       containers:
       - name: {{ .Release.Name }}-deployment-remover
         image: wunderio/silta-deployment-remover:v0.1

--- a/chart/templates/deployment-remover.yaml
+++ b/chart/templates/deployment-remover.yaml
@@ -1,0 +1,62 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-deployment-remover
+  annotations:
+    getambassador.io/config: |
+      apiVersion: ambassador/v0
+      kind:  Mapping
+      name:  {{ .Release.Name }}-deployment-remover
+      host: webhooks.{{ .Values.clusterDomain }}
+      prefix: /
+      service: {{ .Release.Name }}-deployment-remover.{{ .Release.Namespace }}.svc.cluster.local:80
+      timeout_ms: 30000
+    domain: webhooks.{{ .Values.clusterDomain }}  
+spec:
+  type: NodePort
+  externalTrafficPolicy: Local
+  ports:
+    - port: 80
+  selector:
+    name: {{ .Release.Name }}-deployment-remover
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}-deployment-remover
+  annotations:
+    pod.beta.kubernetes.io/init-containers: '[
+      {
+        "name": "wait-redis",
+        "image": "busybox",
+        "command": ["sh", "-c", "until nslookup {{ .Release.Name }}-redis-master; do echo waiting for redis; sleep 2; done;"]
+      },
+    ]'
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        name: {{ .Release.Name }}-deployment-remover
+    spec:
+      containers:
+      - name: {{ .Release.Name }}-deployment-remover
+        image: wunderio/silta-deployment-remover:v0.1
+        ports:
+          - containerPort: 80
+        env:
+          - name: WEBHOOKS_SECRET
+            value: {{ required "A valid .Values.deploymentRemover.webhooksSecret entry required!" .Values.deploymentRemover.webhooksSecret | quote }}
+          - name: REDIS_HOST
+            value: {{ .Release.Name }}-redis-master
+          - name: REDIS_PASSWORD
+            value: {{ required "A valid .Values.redis.password entry required!" .Values.redis.password | quote }}
+          - name: GCLOUD_KEY_JSON
+            value: {{ required "A valid .Values.gke.keyJSON entry required!" .Values.gke.keyJSON | quote }}
+          - name: GCLOUD_PROJECT_NAME
+            value: {{ required "A valid .Values.gke.projectName entry required!" .Values.gke.projectName | quote }}
+          - name: GCLOUD_COMPUTE_ZONE
+            value: {{ required "A valid .Values.gke.computeZone entry required!" .Values.gke.computeZone | quote }}
+          - name: GCLOUD_CLUSTER_NAME
+            value: {{ required "A valid .Values.gke.clusterName entry required!" .Values.gke.clusterName | quote }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1,3 +1,6 @@
+# Main domain of the cluster.
+clusterDomain: "silta.wdr.io"
+
 nfs-server-provisioner:
   persistence:
     enabled: true
@@ -11,3 +14,23 @@ gitAuth:
   host: 'github.com'
   organisation: ''
   apiToken: ''
+
+# Deployment remover
+deploymentRemover:
+  # Github webhooks secret
+  webhooksSecret: ''
+
+# GKE Cluster settings
+gke:
+  keyJSON: ''
+  projectName: '' 
+  computeZone: ''
+  clusterName: ''
+
+# Redis DB for remover queue
+# https://github.com/helm/charts/tree/master/stable/redis
+redis:
+  password: ''
+  cluster:
+    enabled: 0
+    slaveCount: 0


### PR DESCRIPTION
**Story:**
https://wunder.atlassian.net/browse/SLT-25

**Description:**
Exposes webhook that tries to remove deployment based on branch name. 

To set this up, I created a github application with secret and URL that points to webhooks.silta.wdr.io/webhooks. It has to listen branch `delete` event.
App: `https://github.com/organizations/<org name>/settings/apps`
Installed apps: `https://github.com/organizations/<org name>/settings/installations`

Because we have quite a few secrets to set now, I copied `values.yaml`, filled it with our variables and used the file with `--values` parameter in helm deployment. This looks way cleaner now, but we probably take a look at some hosted secrets storage. Updated deployment command mentioned in `README.md` - `helm upgrade --install --wait silta-cluster chart/  --values local-values.yaml`

Remover code can (should) be inspected here: https://github.com/wunderio/silta-deployment-remover/

**Testing:**
1. Made a branch from master, pushed. New environment was created. http://feature-test-removal.drupal-project-k8s.silta.wdr.io/
2. Removed branch from origin, this got logged in remover pod:
```
2018-12-04T12:54:47: PM2 log: Launching in no daemon mode
2018-12-04T12:54:47: PM2 log: App [server:0] starting in -fork mode-
2018-12-04T12:54:47: PM2 log: App [remover:1] starting in -fork mode-
2018-12-04T12:54:47: PM2 log: App [server:0] online
2018-12-04T12:54:47: PM2 log: App [remover:1] online
> silta_git_webhook@1.0.0 server /app
> node server.js
> silta_git_webhook@1.0.0 remover /app
> node remover.js
REMOVER: Waiting for queue entries
listening for hook events on 0.0.0.0:80

POST /webhooks 10.48.6.35
received 7148 bytes from 10.48.6.35
got delete event on drupal-project-k8s:feature/test-removal from 10.48.6.35
SERVER: Branch deletion event
SERVER: Job 5 created
REMOVER: Job 5 started
STDOUT:  Logging on to Google Cloud
Removing release drupal-project-k8s--feature-test-removal
release "drupal-project-k8s--feature-test-removal" deleted
STDERR:  Activated service account credentials for: [silta-circleci@silta-204108.iam.gserviceaccount.com]
Updated property [compute/zone].
Fetching cluster endpoint and auth data.
kubeconfig entry generated for silta-1.
SERVER: Job 5 completed
```
3. Test site is no longer available. http://feature-test-removal.drupal-project-k8s.silta.wdr.io/

**Further improvements:**
 - Publish [Silta Deployment Remover](https://github.com/wunderio/silta-deployment-remover/) repository
 - Add branchname as label to some resource in deployment. Then we can select deployment name based on supplied branchname and there would be no redundant release name generation code.  