### PR TITLE
Wait for redis to return successfully to a PING command

### DIFF
--- a/chart/templates/deployment-remover.yaml
+++ b/chart/templates/deployment-remover.yaml
@@ -35,7 +35,7 @@ spec:
       initContainers:
       - name: wait-redis
         image: busybox
-        command: ["sh", "-c", "until nslookup {{ .Release.Name }}-redis-master; do echo waiting for redis; sleep 2; done;"]
+        command: ["sh", "-c", "until echo PING | nc {{ .Release.Name }}-redis-master 6379; do echo waiting for redis; sleep 2; done;"]
       containers:
       - name: {{ .Release.Name }}-deployment-remover
         image: wunderio/silta-deployment-remover:v0.1

--- a/chart/templates/deployment-remover.yaml
+++ b/chart/templates/deployment-remover.yaml
@@ -35,7 +35,12 @@ spec:
       initContainers:
       - name: wait-redis
         image: busybox
-        command: ["sh", "-c", "until echo PING | nc {{ .Release.Name }}-redis-master 6379; do echo waiting for redis; sleep 2; done;"]
+        command: ['sh', '-c', 'until echo -e "AUTH $REDIS_PASSWORD\nPING" | nc $REDIS_HOST 6379; do echo waiting for redis; sleep 2; done;']
+        env:
+          - name: REDIS_HOST
+            value: {{ .Release.Name }}-redis-master
+          - name: REDIS_PASSWORD
+            value: {{ required "A valid .Values.redis.password entry required!" .Values.redis.password | quote }}
       containers:
       - name: {{ .Release.Name }}-deployment-remover
         image: wunderio/silta-deployment-remover:v0.1


### PR DESCRIPTION
It seems the current initcontainer with `nslookup` is not sufficient to make sure that redis is really up and running. This seems to work (tested by editing the live kubernetes resource). 