### PR TITLE
Remover Image pull policy set to Always

### DIFF
--- a/chart/templates/deployment-remover.yaml
+++ b/chart/templates/deployment-remover.yaml
@@ -41,6 +41,7 @@ spec:
         image: wunderio/silta-deployment-remover:v0.1
         ports:
           - containerPort: 80
+        imagePullPolicy: Always
         env:
           - name: WEBHOOKS_SECRET
             value: {{ required "A valid .Values.deploymentRemover.webhooksSecret entry required!" .Values.deploymentRemover.webhooksSecret | quote }}


### PR DESCRIPTION
Keeps installing an old version of v0.1 even though it's rebuilt in dockerhub. Changing `imagePullPolicy` to `Always`